### PR TITLE
Allowing POST option for long texts without encoding it into url

### DIFF
--- a/src/main/java/org/grobid/service/QuantityRestService.java
+++ b/src/main/java/org/grobid/service/QuantityRestService.java
@@ -87,7 +87,7 @@ public class QuantityRestService implements QuantityPaths {
     @Path(PATH_QUANTITY_TEXT)
     @Produces(MediaType.APPLICATION_JSON + ";charset=utf-8")
     @POST
-    public Response processText_post(@QueryParam(TEXT) String text) {
+    public Response processText_post(@FormParam(TEXT) String text) {
         System.out.println(text);
         return QuantityProcessString.processText(text);
     }


### PR DESCRIPTION
Hi,

I noticed that querying with GET is problematic when the text is very long.

I tried changing `@QueryParam` to  `@FormParam(TEXT)` and that allows to query by `application/x-www-form-urlencoded` of the POST instead of the url way.

P.S: I'm not very familiar with this project feel free to correct me :)

Thank you.