### PR TITLE
The models are automatically copied into your grobid-home

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -153,6 +153,12 @@ artifacts {
     archives shadowJar
 }
 
+task copyModels(type: Copy) {
+    from "${rootDir}/resources/models"
+    include "**/*.wapiti"
+    into "${rootDir}/../grobid-home/models/"
+}
+
 //tasks.withType(JavaCompile) {
 //    options.compilerArgs << "-Xlint:deprecation"
 //    options.compilerArgs << "-Xlint:unchecked"

--- a/doc/gettingStarted.rst
+++ b/doc/gettingStarted.rst
@@ -14,17 +14,13 @@ Copy the module quantities as sibling sub-project to grobid-core, grobid-trainer
 ::
    cp -r grobid-quantities grobid/
 
-*Recent change*: Copy the updated models from `grobid-quantities/resources/models/` to `grobid-home/models`:
-::
-   cp -r grobid-quantities/resources/models/* ../grobid-home/models
-
-You should have the directories of the models `quantities` and `units`
-
 Try compiling everything with:
 ::
    cd PATH-TO-GROBID/grobid/
 
-   ./gradlew clean install
+   ./gradlew clean install copyModels
+
+You should have the directories of the models `quantities` and `units` inside `../grobid-home/models`
 
 Run some test:
 ::


### PR DESCRIPTION
The models are automatically copied into your `grobid-home` instead of manually copying them. Edited the documentation as well to reflect that.