### PR TITLE
Collect the full raw data string in response

### DIFF
--- a/src/main/java/org/grobid/core/data/Measurement.java
+++ b/src/main/java/org/grobid/core/data/Measurement.java
@@ -2,7 +2,9 @@ package org.grobid.core.data;
 
 import com.fasterxml.jackson.core.io.JsonStringEncoder;
 import com.fasterxml.jackson.core.util.BufferRecyclers;
+import org.apache.commons.lang3.StringUtils;
 import org.grobid.core.layout.BoundingBox;
+import org.grobid.core.utilities.OffsetPosition;
 import org.grobid.core.utilities.UnitUtilities;
 
 import java.util.ArrayList;
@@ -29,6 +31,12 @@ public class Measurement {
     private Quantity quantityRange = null;
     private List<Quantity> quantityList = null;
     private QuantifiedObject quantifiedObject = null; // what is quantified, as extracted from the text
+
+    // Contains the raw string (considered from the lower to the higher offset)
+    private String rawString = "";
+
+    //Contains the global lower and higher offsets
+    private OffsetPosition rawOffsets = new OffsetPosition();
 
     // optional bounding box in the source document
     private List<BoundingBox> boundingBoxes = null;
@@ -281,6 +289,18 @@ public class Measurement {
             json.append("] ");
         }
 
+        if (StringUtils.isNotBlank(rawString)) {
+            json.append(", \"measurementRaw\" : \"" + rawString + "\"");
+        }
+
+        if (rawOffsets.start > -1 && rawOffsets.end > -1) {
+            json.append(", \"measurementOffsets\" : {");
+            json.append("\"start\" : " + rawOffsets.start + ", ");
+            json.append("\"end\" : " + rawOffsets.end);
+            json.append("}");
+        }
+
+
         json.append(" }");
         return json.toString();
     }
@@ -308,5 +328,21 @@ public class Measurement {
             (this.getQuantityLeast() != null || this.getQuantityMost() != null) ||
             (this.getQuantityBase() != null && this.getQuantityRange() != null)
         );
+    }
+
+    public void setRawString(String rawString) {
+        this.rawString = rawString;
+    }
+
+    public void setRawOffsets(OffsetPosition rawOffsets) {
+        this.rawOffsets = rawOffsets;
+    }
+
+    public String getRawString() {
+        return rawString;
+    }
+
+    public OffsetPosition getRawOffsets() {
+        return rawOffsets;
     }
 }

--- a/src/main/java/org/grobid/core/engines/QuantityParser.java
+++ b/src/main/java/org/grobid/core/engines/QuantityParser.java
@@ -706,7 +706,7 @@ public class QuantityParser extends AbstractParser {
         measurements.stream().forEach(m -> {
             final Pair<OffsetPosition, String> measurementRawOffsetsAndText = QuantityOperations.getMeasurementRawOffsetsAndText(m, tokens);
             m.setRawOffsets(measurementRawOffsetsAndText.getLeft());
-            m.setRawString(measurementRawOffsetsAndText.getRight());
+            m.setRawString(measurementRawOffsetsAndText.getRight().replace("\n", " "));
         });
 
         measurements = MeasurementOperations.postCorrection(measurements);

--- a/src/main/java/org/grobid/core/engines/QuantityParser.java
+++ b/src/main/java/org/grobid/core/engines/QuantityParser.java
@@ -1,7 +1,9 @@
 package org.grobid.core.engines;
 
+import com.google.common.collect.Iterables;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.grobid.core.GrobidModel;
 import org.grobid.core.analyzers.QuantityAnalyzer;
 import org.grobid.core.data.Measurement;
@@ -27,6 +29,7 @@ import org.slf4j.LoggerFactory;
 import javax.inject.Inject;
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -699,6 +702,12 @@ public class QuantityParser extends AbstractParser {
         if (currentMeasurement.isValid()) {
             measurements.add(currentMeasurement);
         }
+        
+        measurements.stream().forEach(m -> {
+            final Pair<OffsetPosition, String> measurementRawOffsetsAndText = QuantityOperations.getMeasurementRawOffsetsAndText(m, tokens);
+            m.setRawOffsets(measurementRawOffsetsAndText.getLeft());
+            m.setRawString(measurementRawOffsetsAndText.getRight());
+        });
 
         measurements = MeasurementOperations.postCorrection(measurements);
         return measurements;


### PR DESCRIPTION
When using grobid-quantities from other tools, I would need to have the whole full raw data string in the response which include both value and unit. 