### PR TITLE
Fix classname for quantities trainer task in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -151,7 +151,7 @@ task integration(type: Test) {
 def trainerTasks = [
         //Training models
         "train_units"            : "org.grobid.trainer.UnitTrainer",
-        "train_quantities"       : "org.grobid.trainer.QuantityTrainer",
+        "train_quantities"       : "org.grobid.trainer.QuantitiesTrainer",
         "train_values"           : "org.grobid.trainer.ValueTrainer",
         "train_quantifiedObjects": "org.grobid.trainer.QuantifiedObjectTrainer"
 ]


### PR DESCRIPTION
Replaced wrong classname `org.grobid.trainer.QuantityTrainer` with the correct one `org.grobid.trainer.QuantitiesTrainer`, so `./gradlew train_quantities` command will work again.