### PR TITLE
add configurable limit to maximum parallel requests

### DIFF
--- a/doc/restAPI.rst
+++ b/doc/restAPI.rst
@@ -364,3 +364,11 @@ You can check whether the service is up and running by opening the following URL
 - GET ``http://yourhost:8060/service/health`` will return you the result of the health check
 
 - GET ``http://yourhost:8060/service/isalive`` will return true/false whether the service is up and running
+
+
+Maximum parallel requests limit
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This parameter allow to limit the number of parallel requests that can be send to the service. 
+It can be modified in the configuration file the item `maxParallelRequests`.  
+By default, the number is set to 0, which indicate to allow a number of parallel requests not higher than the number of available CPUs. 

--- a/resources/config/config.yml
+++ b/resources/config/config.yml
@@ -4,6 +4,9 @@ corsAllowedOrigins: "*"
 corsAllowedMethods: "OPTIONS,GET,PUT,POST,DELETE,HEAD"
 corsAllowedHeaders: "X-Requested-With,Content-Type,Accept,Origin"
 
+# Limit the maximum number of requests
+maxParallelRequests: 0
+
 views:
   .mustache:
     cache: false

--- a/resources/config/config.yml
+++ b/resources/config/config.yml
@@ -54,8 +54,6 @@ models:
       embeddings_name: "glove-840B"
 
 
-
-
 views:
   .mustache:
     cache: false

--- a/src/main/java/org/grobid/service/configuration/GrobidQuantitiesConfiguration.java
+++ b/src/main/java/org/grobid/service/configuration/GrobidQuantitiesConfiguration.java
@@ -14,6 +14,7 @@ public class GrobidQuantitiesConfiguration extends Configuration {
     @JsonProperty
     private String corsAllowedHeaders = "X-Requested-With,Content-Type,Accept,Origin";
 
+    private int maxParallelRequests;
 
     public String getGrobidHome() {
         return grobidHome;
@@ -45,5 +46,12 @@ public class GrobidQuantitiesConfiguration extends Configuration {
 
     public void setCorsAllowedHeaders(String corsAllowedHeaders) {
         this.corsAllowedHeaders = corsAllowedHeaders;
+    }
+
+    public int getMaxParallelRequests() {
+        if (this.maxParallelRequests == 0) {
+            this.maxParallelRequests = Runtime.getRuntime().availableProcessors();
+        }
+        return this.maxParallelRequests;
     }
 }

--- a/src/main/java/org/grobid/service/main/GrobidQuantitiesApplication.java
+++ b/src/main/java/org/grobid/service/main/GrobidQuantitiesApplication.java
@@ -9,6 +9,7 @@ import io.dropwizard.forms.MultiPartBundle;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import org.eclipse.jetty.servlets.CrossOriginFilter;
+import org.eclipse.jetty.servlets.QoSFilter;
 import org.grobid.service.QuantitiesServiceModule;
 import org.grobid.service.command.RunTrainingCommand;
 import org.grobid.service.command.UnitBatchProcessingCommand;
@@ -70,6 +71,12 @@ public class GrobidQuantitiesApplication extends Application<GrobidQuantitiesCon
 
         // Add URL mapping
         cors.addMappingForUrlPatterns(EnumSet.allOf(DispatcherType.class), true, RESOURCES + "/*");
+
+        // Enable QoS filter
+        final FilterRegistration.Dynamic qos = environment.servlets().addFilter("QOS", QoSFilter.class);
+        qos.addMappingForUrlPatterns(EnumSet.allOf(DispatcherType.class), true, "/*");
+        qos.setInitParameter("maxRequests", String.valueOf(configuration.getMaxParallelRequests()));
+        
     }
 
     public static void main(String[] args) throws Exception {


### PR DESCRIPTION
This PR limit the maximum number of parallel requests from the configuration file. 
The implementation relies on the QOS filter that every request is run through. The server responds 503, like grobid, when running out of slots for requests. 