### PR TITLE
Fix docker build 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 ## docker build -t lfoppiano/grobid-quantities:0.7.0 --build-arg GROBID_VERSION=0.7.0 --file Dockerfile .
 
 ## no GPU:
-## docker run -t --rm --init -p 8072:8072 -p 8073:8073 -v config.yml:/opt/grobid/grobid-quantities:ro  lfoppiano/grobid-quantities:0.7.0
+## docker run -t --rm --init -p 8060:8060 -p 8061:8061 -v config.yml:/opt/grobid/grobid-quantities:ro  lfoppiano/grobid-quantities:0.7.1
 
 ## allocate all available GPUs (only Linux with proper nvidia driver installed on host machine):
 ## docker run --rm --gpus all --init -p 8072:8072 -p 8073:8073 -v grobid.yaml:/opt/grobid/grobid-home/config/grobid.yaml:ro  lfoppiano/grobid-superconductors:0.3.0-SNAPSHOT

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,9 @@ ENV LANG C.UTF-8
 # install JRE 8, python and other dependencies
 RUN apt-key del 7fa2af80 && \
     curl https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb -O cuda-keyring_1.0-1_all.deb && \
-    dpkg -i cuda-keyring_1.0-1_all.deb
+    dpkg -i cuda-keyring_1.0-1_all.deb && \
+    rm /etc/apt/sources.list.d/cuda.list && \
+    rm /etc/apt/sources.list.d/nvidia-ml.list
 RUN apt-get -y --no-install-recommends install git wget
 #    apt-get -y remove python3.6 && \
 #    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,10 +58,8 @@ FROM grobid/grobid:0.7.1
 ENV LANG C.UTF-8
 
 # install JRE 8, python and other dependencies
-RUN apt-get --allow-unauthenticated update && \
-    apt-get install wget && \
-    apt-key del 7fa2af80 && \
-    wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb && \
+RUN apt-key del 7fa2af80 && \
+    curl https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb -O cuda-keyring_1.0-1_all.deb && \
     dpkg -i cuda-keyring_1.0-1_all.deb && \
     apt-get -y --no-install-recommends install git wget
 #    apt-get -y remove python3.6 && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,8 @@ FROM grobid/grobid:0.7.1
 ENV LANG C.UTF-8
 
 # install JRE 8, python and other dependencies
-RUN apt-key del 7fa2af80 && \
+RUN apt-get install wget && \
+    apt-key del 7fa2af80 && \
     wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb && \
     dpkg -i cuda-keyring_1.0-1_all.deb && \
     apt-get update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,11 +58,11 @@ FROM grobid/grobid:0.7.1
 ENV LANG C.UTF-8
 
 # install JRE 8, python and other dependencies
-RUN apt-get install wget && \
+RUN apt-get update && \
+    apt-get install wget && \
     apt-key del 7fa2af80 && \
     wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb && \
     dpkg -i cuda-keyring_1.0-1_all.deb && \
-    apt-get update && \
     apt-get -y --no-install-recommends install git wget
 #    apt-get -y remove python3.6 && \
 #    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ FROM grobid/grobid:0.7.1
 ENV LANG C.UTF-8
 
 # install JRE 8, python and other dependencies
-RUN apt-get update && \
+RUN apt-get --allow-unauthenticated update && \
     apt-get install wget && \
     apt-key del 7fa2af80 && \
     wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ WORKDIR /opt
 # build runtime image
 # -------------------
 
-FROM grobid/grobid:0.7.1
+FROM grobid/grobid:0.7.1 as runtime
 
 # setting locale is likely useless but to be sure
 ENV LANG C.UTF-8
@@ -62,8 +62,10 @@ RUN apt-key del 7fa2af80 && \
     curl https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb -O cuda-keyring_1.0-1_all.deb && \
     dpkg -i cuda-keyring_1.0-1_all.deb && \
     rm /etc/apt/sources.list.d/cuda.list && \
-    rm /etc/apt/sources.list.d/nvidia-ml.list
-RUN apt-get -y --no-install-recommends install git wget
+    rm /etc/apt/sources.list.d/nvidia-ml.list \
+
+RUN apt-get update && \
+    apt-get -y --no-install-recommends install git wget
 #    apt-get -y remove python3.6 && \
 #    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata && \
 #    apt-get -y --no-install-recommends install git python3.7 python3.7-venv python3.7-dev python3.7-distutil

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ RUN apt-key del 7fa2af80 && \
     curl https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb -O cuda-keyring_1.0-1_all.deb && \
     dpkg -i cuda-keyring_1.0-1_all.deb && \
     rm /etc/apt/sources.list.d/cuda.list && \
-    rm /etc/apt/sources.list.d/nvidia-ml.list \
+    rm /etc/apt/sources.list.d/nvidia-ml.list
 
 RUN apt-get update && \
     apt-get -y --no-install-recommends install git wget

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,8 +60,8 @@ ENV LANG C.UTF-8
 # install JRE 8, python and other dependencies
 RUN apt-key del 7fa2af80 && \
     curl https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb -O cuda-keyring_1.0-1_all.deb && \
-    dpkg -i cuda-keyring_1.0-1_all.deb && \
-    apt-get -y --no-install-recommends install git wget
+    dpkg -i cuda-keyring_1.0-1_all.deb
+RUN apt-get -y --no-install-recommends install git wget
 #    apt-get -y remove python3.6 && \
 #    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata && \
 #    apt-get -y --no-install-recommends install git python3.7 python3.7-venv python3.7-dev python3.7-distutil

--- a/resources/config/config-docker.yml
+++ b/resources/config/config-docker.yml
@@ -18,7 +18,7 @@ models:
       nbMaxIterations: 2000
     delft:
       # deep learning parameters
-      architecture: "BidLSTM_CRF"
+      architecture: "BidLSTM_CRF_FEATURES"
       #architecture: "scibert"
       useELMo: false
       embeddings_name: "glove-840B"
@@ -33,14 +33,14 @@ models:
       nbMaxIterations: 2000
     delft:
       # deep learning parameters
-      architecture: "BidLSTM_CRF"
+      architecture: "BidLSTM_CRF_FEATURES"
       #architecture: "scibert"
       useELMo: false
       embeddings_name: "glove-840B"
 
   - name: "values"
-    engine: "wapiti"
-    #engine: "delft"
+#    engine: "wapiti"
+    engine: "delft"
     wapiti:
       # wapiti training parameters, they will be used at training time only
       epsilon: 0.00001
@@ -48,15 +48,11 @@ models:
       nbMaxIterations: 2000
     delft:
       # deep learning parameters
-      architecture: "BidLSTM_CRF"
+      architecture: "BidLSTM_CRF_FEATURES"
       #architecture: "scibert"
       useELMo: false
       embeddings_name: "glove-840B"
 
-
-views:
-  .mustache:
-    cache: false
 
 server:
   type: custom
@@ -77,15 +73,5 @@ logging:
   appenders:
     - type: console
       threshold: INFO
-#Docker-ignore-log-start      
-    - type: file
-      threshold: DEBUG
-      logFormat: "%-6level [%d{HH:mm:ss.SSS}] [%t] %logger{5} - %X{code} %msg %n"
-      currentLogFilename: logs/grobid-quantities.log
-      archivedLogFilenamePattern: logs/grobid-quantities-%d{yyyy-MM-dd}-%i.log.gz
-      archivedFileCount: 7
       timeZone: UTC
-      maxFileSize: 10MB
-#Docker-ignore-log-end
-timeZone: UTC
 


### PR DESCRIPTION
Trying to work around the problems with the apt-get keys that have been changed on the 22nd of April 2022. 

For reference

```
#7 25.36 W: GPG error: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64  InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY A4B469963BF863CC
#7 25.36 E: The repository 'https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64  InRelease' is not signed.
```